### PR TITLE
Support using "safe" Safestrap slot

### DIFF
--- a/prebuilt/bin/fixboot.sh
+++ b/prebuilt/bin/fixboot.sh
@@ -15,6 +15,14 @@ if [ "$SLOT_LOC" = "altpart" ]; then
 /sbin/bbx ln -s /dev/block/webtop /dev/block/system
 
 /sbin/bbx umount /ss
+elif [ "$SLOT_LOC" = "safe" ]; then
+/sbin/bbx mv /dev/block/system /dev/block/systemorig
+/sbin/bbx mv /dev/block/userdata /dev/block/userdataorig
+
+/sbin/bbx ln -s /dev/block/preinstall /dev/block/system
+/sbin/bbx ln -s /dev/block/webtop /dev/block/userdata
+
+/sbin/bbx umount /ss
 elif [ "$SLOT_LOC" != "stock" ]; then
 # setup loopbacks
 /sbin/bbx losetup /dev/block/loop-system /ss/safestrap/$SLOT_LOC/system.img


### PR DESCRIPTION
There is a modified Safestrap 3.75 version which has "safe" slot option added and other changes.
The "safe" slot uses preinstall partition as /system and webtop as /data.
More information: http://www.internauta37.altervista.org/en/xt894-and-xt912-safestrap-375-unused-partitions-preinstall-webtop