### PR TITLE
fixboot: Fix handling of empty SLOT_LOC

### DIFF
--- a/prebuilt/bin/fixboot.sh
+++ b/prebuilt/bin/fixboot.sh
@@ -10,6 +10,13 @@ exec 2>&1
 
 SLOT_LOC=$(/sbin/bbx cat /ss/safestrap/active_slot)
 
+# nothing to do, default to mmcblk1p20 system partition
+if [ "$SLOT_LOC" = "" ] || [ "$SLOT_LOC" = "stock" ]; then
+	/sbin/bbx umount /ss
+	exit 0
+fi
+
+# handle alternative system partitions and SafeStrap slots
 if [ "$SLOT_LOC" = "altpart" ]; then
 /sbin/bbx mv /dev/block/system /dev/block/systemorig
 /sbin/bbx ln -s /dev/block/webtop /dev/block/system


### PR DESCRIPTION
If mmcblk1p25 emstorage is formatted as ext4 or something other than
vfat, booting the stock partition fails because we wrongly try mount
the loopback devices. This happens because SLOT_LOCK is empty
and we still pass the "$SLOT_LOC" != "stock" test.

Let's fix the issue by bailing out early if SLOT_LOC is empty.